### PR TITLE
feat: Mock Gbx Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,70 @@ func handleDisconnect(eventChan chan any) {
 	}
 }
 ```
+
+## Mock Server
+
+GbxRemoteGo includes a mock server for testing and development purposes. The mock server implements the same XML-RPC protocol as real Trackmania servers, allowing you to test your applications without needing a running game server.
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "log"
+    "time"
+    
+    "github.com/MRegterschot/GbxRemoteGo/gbxclient"
+    "github.com/MRegterschot/GbxRemoteGo/mockserver"
+)
+
+func main() {
+    // Create and start mock server
+    mock := mockserver.New(mockserver.Config{
+        Host: "127.0.0.1",
+        Port: 5000,
+    })
+    
+    if err := mock.Start(); err != nil {
+        log.Fatal("Failed to start mock server:", err)
+    }
+    defer mock.Stop()
+    
+    // Set custom responses for specific methods
+    mock.SetResponse("TriggerModeScriptEventArray", "Pause activated")
+    mock.SetResponse("GetVersion", map[string]interface{}{
+        "Name":    "MyMockServer",
+        "Version": "1.0.0",
+    })
+    
+    // Connect client to mock server
+    client := gbxclient.NewGbxClient("127.0.0.1", 5000, gbxclient.Options{})
+    client.Connect()
+    client.SetApiVersion("2023-04-24")
+    client.Authenticate("SuperAdmin", "SuperAdmin")
+    
+    // Use client normally - calls go to mock server
+    version, _ := client.GetVersion()
+    println("Connected to:", version.Name)
+}
+```
+
+### Features
+
+- **Full XML-RPC compatibility** with existing client code
+- **Custom response injection** for specific method calls
+- **Default responses** for common methods (authentication, version info, etc.)
+- **Easy testing setup** for unit tests and integration tests
+- **No external dependencies** beyond the existing codebase
+
+### Default Supported Methods
+
+The mock server provides default responses for:
+- `SetApiVersion`, `EnableCallbacks`, `Authenticate` - Always return success
+- `GetVersion`, `GetStatus`, `GetSystemInfo` - Return mock server information
+- `TriggerModeScriptEvent`, `TriggerModeScriptEventArray` - Accept calls without error
+- `RestartMap`, `NextMap` - Accept calls without error
+
+For any other method calls, the mock server returns a generic success response unless you've set a custom response using `SetResponse()`.
+

--- a/README.md
+++ b/README.md
@@ -153,9 +153,61 @@ func main() {
 
 - **Full XML-RPC compatibility** with existing client code
 - **Custom response injection** for specific method calls
+- **Auto-port assignment** - automatically finds available ports to avoid conflicts
+- **Method call tracking** - record and verify which methods were called
 - **Default responses** for common methods (authentication, version info, etc.)
 - **Easy testing setup** for unit tests and integration tests
 - **No external dependencies** beyond the existing codebase
+
+### Auto-Port Assignment
+
+The mock server can automatically find an available port:
+
+```go
+// Create a server that automatically finds an available port
+mock := mockserver.NewWithAutoPort("127.0.0.1")
+mock.Start()
+
+fmt.Printf("Server listening on %s\n", mock.Address())
+// Outputs: Server listening on 127.0.0.1:5001 (or next available port)
+
+// Get the assigned port for client connections
+client := gbxclient.NewGbxClient("127.0.0.1", mock.Port(), gbxclient.Options{})
+```
+
+Or use the Config approach:
+
+```go
+mock := mockserver.New(mockserver.Config{
+    Host:     "127.0.0.1",
+    AutoPort: true, // Automatically find available port
+})
+```
+
+### Method Call Tracking
+
+Track which methods were called for testing verification:
+
+```go
+mock := mockserver.NewWithAutoPort("127.0.0.1")
+mock.Start()
+
+// ... make some calls with your client ...
+
+// Verify calls were made
+calls := mock.GetMethodCalls()
+if len(calls) == 0 {
+    t.Error("Expected method calls but got none")
+}
+
+// Check if specific method was called
+if mock.WasMethodCalled("SetApiVersion") {
+    fmt.Println("SetApiVersion was called!")
+}
+
+// Reset call history for next test
+mock.ClearMethodCalls()
+```
 
 ### Default Supported Methods
 

--- a/mockserver/examples/example.go
+++ b/mockserver/examples/example.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/MRegterschot/GbxRemoteGo/gbxclient"
+	"github.com/MRegterschot/GbxRemoteGo/mockserver"
+)
+
+func main() {
+	// Create and start mock server
+	mock := mockserver.New(mockserver.Config{
+		Host: "127.0.0.1",
+		Port: 5000,
+	})
+
+	// Set custom response for TriggerModeScriptEventArray
+	mock.SetResponse("TriggerModeScriptEventArray", "Custom response: Pause activated")
+
+	// Start the mock server
+	if err := mock.Start(); err != nil {
+		log.Fatal("Failed to start mock server:", err)
+	}
+	defer mock.Stop()
+
+	fmt.Println("Mock server started on port", mock.Port())
+
+	// Give the server a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Create and connect client
+	client := gbxclient.NewGbxClient("127.0.0.1", 5000, gbxclient.Options{})
+
+	// Connect to the mock server
+	if err := client.Connect(); err != nil {
+		log.Fatal("Failed to connect:", err)
+	}
+	defer client.Disconnect()
+
+	// Authenticate
+	if err := client.SetApiVersion("2023-04-24"); err != nil {
+		log.Fatal("Failed to set API version:", err)
+	}
+
+	if err := client.EnableCallbacks(true); err != nil {
+		log.Fatal("Failed to enable callbacks:", err)
+	}
+
+	if err := client.Authenticate("SuperAdmin", "SuperAdmin"); err != nil {
+		log.Fatal("Failed to authenticate:", err)
+	}
+
+	fmt.Println("Client connected and authenticated successfully!")
+
+	// Test some method calls
+	version, err := client.GetVersion()
+	if err != nil {
+		log.Fatal("Failed to get version:", err)
+	}
+	fmt.Printf("Server version: %+v\n", version)
+
+	status, err := client.GetStatus()
+	if err != nil {
+		log.Fatal("Failed to get status:", err)
+	}
+	fmt.Printf("Server status: %+v\n", status)
+
+	// Test the custom response we set
+	err = client.TriggerModeScriptEventArray("Maniaplanet.Pause.SetActive", []string{"true"})
+	if err != nil {
+		log.Fatal("Failed to trigger script event:", err)
+	}
+	fmt.Println("Successfully triggered script event!")
+
+	// Test another method call
+	err = client.RestartMap()
+	if err != nil {
+		log.Fatal("Failed to restart map:", err)
+	}
+	fmt.Println("Successfully called RestartMap!")
+
+	fmt.Println("Example completed successfully!")
+}

--- a/mockserver/examples/example.go
+++ b/mockserver/examples/example.go
@@ -10,11 +10,8 @@ import (
 )
 
 func main() {
-	// Create and start mock server
-	mock := mockserver.New(mockserver.Config{
-		Host: "127.0.0.1",
-		Port: 5000,
-	})
+	// Create and start mock server with auto-port assignment
+	mock := mockserver.NewWithAutoPort("127.0.0.1")
 
 	// Set custom response for TriggerModeScriptEventArray
 	mock.SetResponse("TriggerModeScriptEventArray", "Custom response: Pause activated")
@@ -25,13 +22,13 @@ func main() {
 	}
 	defer mock.Stop()
 
-	fmt.Println("Mock server started on port", mock.Port())
+	fmt.Printf("Mock server started on %s\n", mock.Address())
 
 	// Give the server a moment to start
 	time.Sleep(100 * time.Millisecond)
 
-	// Create and connect client
-	client := gbxclient.NewGbxClient("127.0.0.1", 5000, gbxclient.Options{})
+	// Create and connect client using the assigned port
+	client := gbxclient.NewGbxClient("127.0.0.1", mock.Port(), gbxclient.Options{})
 
 	// Connect to the mock server
 	if err := client.Connect(); err != nil {

--- a/mockserver/mockserver.go
+++ b/mockserver/mockserver.go
@@ -7,22 +7,49 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 )
+
+// findAvailablePort finds an available port starting from the given port
+func findAvailablePort(startPort int, host string) (int, error) {
+	if startPort == 0 {
+		startPort = 5000 // Default starting port
+	}
+
+	for port := startPort; port < startPort+1000; port++ {
+		address := fmt.Sprintf("%s:%d", host, port)
+		listener, err := net.Listen("tcp", address)
+		if err == nil {
+			listener.Close()
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port found in range %d-%d", startPort, startPort+999)
+}
+
+// MethodCall represents a recorded method call
+type MethodCall struct {
+	Method    string        `json:"method"`
+	Params    []interface{} `json:"params"`
+	Timestamp time.Time     `json:"timestamp"`
+}
 
 // MockServer represents a mock GBX XML-RPC server
 type MockServer struct {
-	host      string
-	port      int
-	listener  net.Listener
-	responses map[string]interface{}
-	mutex     sync.RWMutex
-	running   bool
+	host        string
+	port        int
+	listener    net.Listener
+	responses   map[string]interface{}
+	methodCalls []MethodCall
+	mutex       sync.RWMutex
+	running     bool
 }
 
 // Config holds configuration for the mock server
 type Config struct {
-	Host string
-	Port int
+	Host     string
+	Port     int  // Set to 0 to auto-assign an available port
+	AutoPort bool // If true, automatically find next available port
 }
 
 // New creates a new mock server instance
@@ -30,15 +57,41 @@ func New(config Config) *MockServer {
 	if config.Host == "" {
 		config.Host = "127.0.0.1"
 	}
-	if config.Port == 0 {
-		config.Port = 5000
+
+	port := config.Port
+	if config.AutoPort || config.Port == 0 {
+		// Find an available port
+		availablePort, err := findAvailablePort(config.Port, config.Host)
+		if err != nil {
+			// Fallback to default port if auto-assignment fails
+			port = 5000
+		} else {
+			port = availablePort
+		}
+	}
+
+	if port == 0 {
+		port = 5000
 	}
 
 	return &MockServer{
-		host:      config.Host,
-		port:      config.Port,
-		responses: make(map[string]interface{}),
+		host:        config.Host,
+		port:        port,
+		responses:   make(map[string]interface{}),
+		methodCalls: make([]MethodCall, 0),
 	}
+}
+
+// NewWithAutoPort creates a new mock server instance that automatically finds an available port
+func NewWithAutoPort(host string) *MockServer {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+
+	return New(Config{
+		Host:     host,
+		AutoPort: true,
+	})
 }
 
 // SetResponse sets a custom response for a specific method
@@ -46,6 +99,65 @@ func (s *MockServer) SetResponse(method string, response interface{}) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.responses[method] = response
+}
+
+// GetMethodCalls returns a copy of all recorded method calls
+func (s *MockServer) GetMethodCalls() []MethodCall {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	// Return a copy to prevent external modification
+	calls := make([]MethodCall, len(s.methodCalls))
+	copy(calls, s.methodCalls)
+	return calls
+}
+
+// GetMethodCallsFor returns all calls for a specific method
+func (s *MockServer) GetMethodCallsFor(method string) []MethodCall {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var calls []MethodCall
+	for _, call := range s.methodCalls {
+		if call.Method == method {
+			calls = append(calls, call)
+		}
+	}
+	return calls
+}
+
+// WasMethodCalled returns true if the specified method was called
+func (s *MockServer) WasMethodCalled(method string) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for _, call := range s.methodCalls {
+		if call.Method == method {
+			return true
+		}
+	}
+	return false
+}
+
+// GetCallCount returns the number of times a method was called
+func (s *MockServer) GetCallCount(method string) int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	count := 0
+	for _, call := range s.methodCalls {
+		if call.Method == method {
+			count++
+		}
+	}
+	return count
+}
+
+// ClearMethodCalls clears the method call history
+func (s *MockServer) ClearMethodCalls() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.methodCalls = make([]MethodCall, 0)
 }
 
 // Start starts the mock server
@@ -74,6 +186,11 @@ func (s *MockServer) Stop() error {
 // Port returns the port the server is listening on
 func (s *MockServer) Port() int {
 	return s.port
+}
+
+// Address returns the full address (host:port) the server is listening on
+func (s *MockServer) Address() string {
+	return fmt.Sprintf("%s:%d", s.host, s.port)
 }
 
 func (s *MockServer) acceptConnections() {
@@ -155,6 +272,21 @@ func (s *MockServer) processRequest(xmlData []byte) []byte {
 		return s.buildErrorResponse("Parse error: " + err.Error())
 	}
 
+	// Extract parameters
+	var params []interface{}
+	for _, param := range methodCall.Params.Params {
+		if param.Value.String != "" {
+			params = append(params, param.Value.String)
+		} else if param.Value.Int != 0 {
+			params = append(params, param.Value.Int)
+		} else if param.Value.Boolean != 0 {
+			params = append(params, param.Value.Boolean == 1)
+		}
+	}
+
+	// Record the method call
+	s.recordMethodCall(methodCall.MethodName, params)
+
 	// Get method response
 	s.mutex.RLock()
 	customResponse, hasCustom := s.responses[methodCall.MethodName]
@@ -168,6 +300,20 @@ func (s *MockServer) processRequest(xmlData []byte) []byte {
 	}
 
 	return s.buildSuccessResponse(result)
+}
+
+// recordMethodCall records a method call for tracking purposes
+func (s *MockServer) recordMethodCall(method string, params []interface{}) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	call := MethodCall{
+		Method:    method,
+		Params:    params,
+		Timestamp: time.Now(),
+	}
+
+	s.methodCalls = append(s.methodCalls, call)
 }
 
 func (s *MockServer) getDefaultResponse(method string) interface{} {

--- a/mockserver/mockserver.go
+++ b/mockserver/mockserver.go
@@ -1,0 +1,307 @@
+package mockserver
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+)
+
+// MockServer represents a mock GBX XML-RPC server
+type MockServer struct {
+	host      string
+	port      int
+	listener  net.Listener
+	responses map[string]interface{}
+	mutex     sync.RWMutex
+	running   bool
+}
+
+// Config holds configuration for the mock server
+type Config struct {
+	Host string
+	Port int
+}
+
+// New creates a new mock server instance
+func New(config Config) *MockServer {
+	if config.Host == "" {
+		config.Host = "127.0.0.1"
+	}
+	if config.Port == 0 {
+		config.Port = 5000
+	}
+
+	return &MockServer{
+		host:      config.Host,
+		port:      config.Port,
+		responses: make(map[string]interface{}),
+	}
+}
+
+// SetResponse sets a custom response for a specific method
+func (s *MockServer) SetResponse(method string, response interface{}) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.responses[method] = response
+}
+
+// Start starts the mock server
+func (s *MockServer) Start() error {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.host, s.port))
+	if err != nil {
+		return err
+	}
+
+	s.listener = listener
+	s.running = true
+
+	go s.acceptConnections()
+	return nil
+}
+
+// Stop stops the mock server
+func (s *MockServer) Stop() error {
+	s.running = false
+	if s.listener != nil {
+		return s.listener.Close()
+	}
+	return nil
+}
+
+// Port returns the port the server is listening on
+func (s *MockServer) Port() int {
+	return s.port
+}
+
+func (s *MockServer) acceptConnections() {
+	for s.running {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if s.running {
+				fmt.Printf("Error accepting connection: %v\n", err)
+			}
+			continue
+		}
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *MockServer) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	// Send initial handshake response when client connects
+	handshake := "GBXRemote 2"
+	s.sendResponse(conn, []byte(handshake))
+
+	for {
+		// Read length header (4 bytes)
+		lengthBytes := make([]byte, 4)
+		_, err := io.ReadFull(conn, lengthBytes)
+		if err != nil {
+			return
+		}
+
+		// Convert length from little endian (GBX protocol uses little endian)
+		length := uint32(lengthBytes[0]) | uint32(lengthBytes[1])<<8 |
+			uint32(lengthBytes[2])<<16 | uint32(lengthBytes[3])<<24
+
+		// Read the handle (4 bytes)
+		handleBytes := make([]byte, 4)
+		_, err = io.ReadFull(conn, handleBytes)
+		if err != nil {
+			return
+		}
+
+		// Read the XML data (length bytes)
+		xmlData := make([]byte, length)
+		_, err = io.ReadFull(conn, xmlData)
+		if err != nil {
+			return
+		} // Process the request and send response
+		response := s.processRequest(xmlData)
+		responseWithHandle := append(handleBytes, response...)
+		s.sendResponse(conn, responseWithHandle)
+	}
+}
+
+func (s *MockServer) processRequest(xmlData []byte) []byte {
+	// Parse XML-RPC request using a simplified structure
+	type XMLRPCValue struct {
+		String  string `xml:"string"`
+		Int     int    `xml:"i4"`
+		Boolean int    `xml:"boolean"`
+	}
+
+	type XMLRPCParam struct {
+		Value XMLRPCValue `xml:"value"`
+	}
+
+	type XMLRPCParams struct {
+		Params []XMLRPCParam `xml:"param"`
+	}
+
+	type XMLRPCMethodCall struct {
+		XMLName    xml.Name     `xml:"methodCall"`
+		MethodName string       `xml:"methodName"`
+		Params     XMLRPCParams `xml:"params"`
+	}
+
+	var methodCall XMLRPCMethodCall
+	err := xml.Unmarshal(xmlData, &methodCall)
+	if err != nil {
+		return s.buildErrorResponse("Parse error: " + err.Error())
+	}
+
+	// Get method response
+	s.mutex.RLock()
+	customResponse, hasCustom := s.responses[methodCall.MethodName]
+	s.mutex.RUnlock()
+
+	var result interface{}
+	if hasCustom {
+		result = customResponse
+	} else {
+		result = s.getDefaultResponse(methodCall.MethodName)
+	}
+
+	return s.buildSuccessResponse(result)
+}
+
+func (s *MockServer) getDefaultResponse(method string) interface{} {
+	switch method {
+	case "SetApiVersion":
+		return true
+	case "EnableCallbacks":
+		return true
+	case "Authenticate":
+		return true
+	case "GetVersion":
+		return map[string]interface{}{
+			"Name":       "MockServer",
+			"TitleId":    "Trackmania",
+			"Version":    "1.0.0",
+			"Build":      "2024-01-01",
+			"ApiVersion": "2023-04-24",
+		}
+	case "GetStatus":
+		return map[string]interface{}{
+			"Code": 4,
+			"Name": "Running",
+		}
+	case "GetSystemInfo":
+		return map[string]interface{}{
+			"PublishedIp":    "127.0.0.1",
+			"Port":           s.port,
+			"P2PPort":        0,
+			"Title":          "TmForever",
+			"ServerLogin":    "MockServer",
+			"ServerPlayerId": 0,
+		}
+	case "TriggerModeScriptEvent", "TriggerModeScriptEventArray":
+		return true
+	case "RestartMap", "NextMap":
+		return true
+	default:
+		return true // Default success response
+	}
+}
+
+func (s *MockServer) buildSuccessResponse(result interface{}) []byte {
+	var valueXML string
+
+	switch v := result.(type) {
+	case bool:
+		if v {
+			valueXML = "<value><boolean>1</boolean></value>"
+		} else {
+			valueXML = "<value><boolean>0</boolean></value>"
+		}
+	case string:
+		valueXML = fmt.Sprintf("<value><string>%s</string></value>", v)
+	case int:
+		valueXML = fmt.Sprintf("<value><i4>%d</i4></value>", v)
+	case map[string]interface{}:
+		valueXML = s.buildStructXML(v)
+	default:
+		valueXML = "<value><string>OK</string></value>"
+	}
+
+	response := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+  <params>
+    <param>
+      %s
+    </param>
+  </params>
+</methodResponse>`, valueXML)
+
+	return []byte(response)
+}
+
+func (s *MockServer) buildStructXML(data map[string]interface{}) string {
+	var members strings.Builder
+	for key, value := range data {
+		var valueXML string
+		switch v := value.(type) {
+		case string:
+			valueXML = fmt.Sprintf("<string>%s</string>", v)
+		case int:
+			valueXML = fmt.Sprintf("<i4>%d</i4>", v)
+		case bool:
+			if v {
+				valueXML = "<boolean>1</boolean>"
+			} else {
+				valueXML = "<boolean>0</boolean>"
+			}
+		default:
+			valueXML = fmt.Sprintf("<string>%v</string>", v)
+		}
+
+		members.WriteString(fmt.Sprintf(`
+      <member>
+        <name>%s</name>
+        <value>%s</value>
+      </member>`, key, valueXML))
+	}
+
+	return fmt.Sprintf("<value><struct>%s</struct></value>", members.String())
+}
+
+func (s *MockServer) buildErrorResponse(message string) []byte {
+	response := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+  <fault>
+    <value>
+      <struct>
+        <member>
+          <name>faultCode</name>
+          <value><int>-1</int></value>
+        </member>
+        <member>
+          <name>faultString</name>
+          <value><string>%s</string></value>
+        </member>
+      </struct>
+    </value>
+  </fault>
+</methodResponse>`, message)
+
+	return []byte(response)
+}
+
+func (s *MockServer) sendResponse(conn net.Conn, response []byte) {
+	// Send length header (4 bytes, little endian)
+	length := uint32(len(response))
+	lengthBytes := []byte{
+		byte(length),
+		byte(length >> 8),
+		byte(length >> 16),
+		byte(length >> 24),
+	}
+
+	conn.Write(lengthBytes)
+	conn.Write(response)
+}

--- a/mockserver/mockserver_test.go
+++ b/mockserver/mockserver_test.go
@@ -1,0 +1,127 @@
+package mockserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MRegterschot/GbxRemoteGo/gbxclient"
+)
+
+func TestMockServer(t *testing.T) {
+	// Create and start mock server
+	mock := New(Config{
+		Host: "127.0.0.1",
+		Port: 5001, // Use different port for tests
+	})
+
+	// Set a custom response
+	mock.SetResponse("GetVersion", map[string]interface{}{
+		"Name":    "TestServer",
+		"Version": "1.0.0-test",
+	})
+
+	if err := mock.Start(); err != nil {
+		t.Fatal("Failed to start mock server:", err)
+	}
+	defer mock.Stop()
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Create client and connect
+	client := gbxclient.NewGbxClient("127.0.0.1", 5001, gbxclient.Options{})
+	if err := client.Connect(); err != nil {
+		t.Fatal("Failed to connect to mock server:", err)
+	}
+	defer client.Disconnect()
+
+	// Test authentication flow
+	if err := client.SetApiVersion("2023-04-24"); err != nil {
+		t.Fatal("Failed to set API version:", err)
+	}
+
+	if err := client.EnableCallbacks(true); err != nil {
+		t.Fatal("Failed to enable callbacks:", err)
+	}
+
+	if err := client.Authenticate("test", "test"); err != nil {
+		t.Fatal("Failed to authenticate:", err)
+	}
+
+	// Test custom response
+	version, err := client.GetVersion()
+	if err != nil {
+		t.Fatal("Failed to get version:", err)
+	}
+
+	if version.Name != "TestServer" {
+		t.Errorf("Expected Name='TestServer', got '%s'", version.Name)
+	}
+
+	if version.Version != "1.0.0-test" {
+		t.Errorf("Expected Version='1.0.0-test', got '%s'", version.Version)
+	}
+
+	// Test default response
+	status, err := client.GetStatus()
+	if err != nil {
+		t.Fatal("Failed to get status:", err)
+	}
+
+	if status.Code != 4 {
+		t.Errorf("Expected status code 4, got %d", status.Code)
+	}
+
+	// Test script event methods
+	err = client.TriggerModeScriptEvent("Trackmania.Pause.SetActive", "true")
+	if err != nil {
+		t.Fatal("Failed to trigger script event:", err)
+	}
+
+	err = client.TriggerModeScriptEventArray("Trackmania.ForceEndRound", []string{})
+	if err != nil {
+		t.Fatal("Failed to trigger script event array:", err)
+	}
+}
+
+func TestMockServerCustomResponses(t *testing.T) {
+	mock := New(Config{
+		Host: "127.0.0.1",
+		Port: 5002,
+	})
+
+	// Test different response types
+	mock.SetResponse("TestString", "Hello World")
+	mock.SetResponse("TestInt", 42)
+	mock.SetResponse("TestBool", true)
+	mock.SetResponse("TestStruct", map[string]interface{}{
+		"Field1": "value1",
+		"Field2": 123,
+		"Field3": false,
+	})
+
+	if err := mock.Start(); err != nil {
+		t.Fatal("Failed to start mock server:", err)
+	}
+	defer mock.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	client := gbxclient.NewGbxClient("127.0.0.1", 5002, gbxclient.Options{})
+	if err := client.Connect(); err != nil {
+		t.Fatal("Failed to connect:", err)
+	}
+	defer client.Disconnect()
+
+	// Basic auth
+	client.SetApiVersion("2023-04-24")
+	client.EnableCallbacks(true)
+	client.Authenticate("test", "test")
+
+	// These would be tested if we had generic Call method exposed
+	// For now, we test that the mock server handles unknown methods gracefully
+	err := client.TriggerModeScriptEvent("TestString", "")
+	if err != nil {
+		t.Fatal("Mock server should handle unknown methods gracefully:", err)
+	}
+}

--- a/mockserver/mockserver_test.go
+++ b/mockserver/mockserver_test.go
@@ -1,6 +1,7 @@
 package mockserver
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -123,5 +124,171 @@ func TestMockServerCustomResponses(t *testing.T) {
 	err := client.TriggerModeScriptEvent("TestString", "")
 	if err != nil {
 		t.Fatal("Mock server should handle unknown methods gracefully:", err)
+	}
+}
+
+func TestMockServerAutoPort(t *testing.T) {
+	// Test creating a server with auto-port
+	mock1 := NewWithAutoPort("127.0.0.1")
+
+	if err := mock1.Start(); err != nil {
+		t.Fatal("Failed to start first mock server:", err)
+	}
+	defer mock1.Stop()
+
+	port1 := mock1.Port()
+	t.Logf("First server got port: %d", port1)
+
+	// Create a second server, should get a different port
+	mock2 := NewWithAutoPort("127.0.0.1")
+
+	if err := mock2.Start(); err != nil {
+		t.Fatal("Failed to start second mock server:", err)
+	}
+	defer mock2.Stop()
+
+	port2 := mock2.Port()
+	t.Logf("Second server got port: %d", port2)
+
+	if port1 == port2 {
+		t.Error("Both servers got the same port, auto-port assignment failed")
+	}
+
+	// Test that both servers work
+	client1 := gbxclient.NewGbxClient("127.0.0.1", port1, gbxclient.Options{})
+	if err := client1.Connect(); err != nil {
+		t.Fatal("Failed to connect to first server:", err)
+	}
+	defer client1.Disconnect()
+
+	client2 := gbxclient.NewGbxClient("127.0.0.1", port2, gbxclient.Options{})
+	if err := client2.Connect(); err != nil {
+		t.Fatal("Failed to connect to second server:", err)
+	}
+	defer client2.Disconnect()
+
+	// Test both connections work
+	if err := client1.SetApiVersion("2023-04-24"); err != nil {
+		t.Fatal("Failed to set API version on first server:", err)
+	}
+
+	if err := client2.SetApiVersion("2023-04-24"); err != nil {
+		t.Fatal("Failed to set API version on second server:", err)
+	}
+}
+
+func TestMockServerConfigAutoPort(t *testing.T) {
+	// Test using Config with AutoPort = true
+	mock := New(Config{
+		Host:     "127.0.0.1",
+		AutoPort: true,
+	})
+
+	if err := mock.Start(); err != nil {
+		t.Fatal("Failed to start mock server with AutoPort:", err)
+	}
+	defer mock.Stop()
+
+	port := mock.Port()
+	address := mock.Address()
+
+	t.Logf("Server with AutoPort got port: %d, address: %s", port, address)
+
+	if port == 0 {
+		t.Error("AutoPort failed to assign a port")
+	}
+
+	expectedAddress := fmt.Sprintf("127.0.0.1:%d", port)
+	if address != expectedAddress {
+		t.Errorf("Expected address %s, got %s", expectedAddress, address)
+	}
+}
+
+func TestMockServerMethodTracking(t *testing.T) {
+	mock := New(Config{
+		Host: "127.0.0.1",
+		Port: 5003,
+	})
+
+	if err := mock.Start(); err != nil {
+		t.Fatal("Failed to start mock server:", err)
+	}
+	defer mock.Stop()
+
+	time.Sleep(100 * time.Millisecond)
+
+	client := gbxclient.NewGbxClient("127.0.0.1", 5003, gbxclient.Options{})
+	if err := client.Connect(); err != nil {
+		t.Fatal("Failed to connect:", err)
+	}
+	defer client.Disconnect()
+
+	// Basic auth
+	client.SetApiVersion("2023-04-24")
+	client.EnableCallbacks(true)
+	client.Authenticate("test", "test")
+
+	// Clear any existing calls from authentication
+	mock.ClearMethodCalls()
+
+	// Test method tracking
+	client.TriggerModeScriptEvent("Trackmania.Pause.SetActive", "true")
+	client.RestartMap()
+	client.GetVersion()
+
+	// Verify method calls were tracked
+	if !mock.WasMethodCalled("TriggerModeScriptEvent") {
+		t.Error("Expected TriggerModeScriptEvent to be called")
+	}
+
+	if !mock.WasMethodCalled("RestartMap") {
+		t.Error("Expected RestartMap to be called")
+	}
+
+	if !mock.WasMethodCalled("GetVersion") {
+		t.Error("Expected GetVersion to be called")
+	}
+
+	// Test call count
+	if count := mock.GetCallCount("TriggerModeScriptEvent"); count != 1 {
+		t.Errorf("Expected TriggerModeScriptEvent to be called 1 time, got %d", count)
+	}
+
+	// Test getting calls for specific method
+	calls := mock.GetMethodCallsFor("TriggerModeScriptEvent")
+	if len(calls) != 1 {
+		t.Errorf("Expected 1 call for TriggerModeScriptEvent, got %d", len(calls))
+	}
+
+	if len(calls) > 0 {
+		call := calls[0]
+		if call.Method != "TriggerModeScriptEvent" {
+			t.Errorf("Expected method name 'TriggerModeScriptEvent', got '%s'", call.Method)
+		}
+
+		if len(call.Params) != 2 {
+			t.Errorf("Expected 2 parameters, got %d", len(call.Params))
+		}
+
+		if len(call.Params) >= 2 {
+			if call.Params[0] != "Trackmania.Pause.SetActive" {
+				t.Errorf("Expected first param 'Trackmania.Pause.SetActive', got '%v'", call.Params[0])
+			}
+			if call.Params[1] != "true" {
+				t.Errorf("Expected second param 'true', got '%v'", call.Params[1])
+			}
+		}
+	}
+
+	// Test getting all calls
+	allCalls := mock.GetMethodCalls()
+	if len(allCalls) != 3 {
+		t.Errorf("Expected 3 total calls, got %d", len(allCalls))
+	}
+
+	// Test clearing calls
+	mock.ClearMethodCalls()
+	if len(mock.GetMethodCalls()) != 0 {
+		t.Error("Expected no calls after clearing")
 	}
 }


### PR DESCRIPTION
PR to add mock gbx server for testing programs that use the gbx client. For instance, when building a custom controller, it is useful to set up a mock gbx server that can capture and respond to commands.